### PR TITLE
add functionality to update a note offline and fix some edge cases

### DIFF
--- a/backend/controllers/note.js
+++ b/backend/controllers/note.js
@@ -109,9 +109,22 @@ exports.deleteNoteById = function (req, res, next) {
  */
 
 exports.updateNoteById = function (req, res, next) {
-  Note.findByIdAndUpdate(req.params.id, req.body, function (err, note) {
+  Note.findById(req.params.id, function (err, note) {
     if (err) return next(err);
     if (!note) return res.status(404).send('note does not exist');
-    return res.sendStatus(200);
+
+    if (note.lastSaved.getTime() < new Date(req.body.lastSaved).getTime()) {
+      note.title = req.body.title;
+      note.content = req.body.content;
+      note.lastSaved = new Date(req.body.lastSaved);
+      
+      note.save(function (err, note) {
+        if (err) return next (err);
+        return res.sendStatus(200);
+      });
+
+    } else {
+      return res.sendStatus(200);
+    }
   });
 }

--- a/backend/models/schemas/note.js
+++ b/backend/models/schemas/note.js
@@ -5,7 +5,9 @@ let Schema = mongoose.Schema;
 let noteSchema = new Schema({
   content: { type: String, required: true },
   title: { type: String, required: true },
-  creator: {type: Schema.Types.ObjectId, ref: 'User' }
+  creator: {type: Schema.Types.ObjectId, ref: 'User' },
+  createdAt: { type: Date, default: new Date() },
+  lastSaved: { type: Date, default: new Date() }
 });
 
 let Note = mongoose.model('Note', noteSchema);

--- a/frontend/src/shared/online-check.js
+++ b/frontend/src/shared/online-check.js
@@ -35,13 +35,32 @@ export function createOfflineToOnline () {
           credentials: 'include',
           method: 'DELETE'
         })
-          .catch(err => {
-            console.log('err in deleting note', err);
-          });
+        .catch(err => {
+          console.log('err in deleting note', err);
+        });
       });
 
       // remove deletedNotes from localStorage
       localStorage.removeItem('deletedNotes');
+    }
+
+    if (localStorage.updatedNotes && JSON.parse(localStorage.updatedNotes).length > 0) {
+      let updatedNotes = JSON.parse(localStorage.updatedNotes);
+
+
+      updatedNotes.forEach(note => {
+        fetch(config.BACKEND_URL + '/note/' + note._id, {
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          method: 'PUT',
+          body: JSON.stringify(note)
+        })
+        .catch(err => {
+          console.log(err)
+        });
+      });
+
+      localStorage.removeItem('updatedNotes');
     }
   }
 }

--- a/frontend/src/store/actions/note.js
+++ b/frontend/src/store/actions/note.js
@@ -24,8 +24,7 @@ export const GetAllUserNotesAction = () => {
       })
       .then((notes) => {
         // store notes into localstorage
-        // to use when the user is offline 
-
+        // to use when the user is offline
         localStorage.setItem('notes', JSON.stringify(notes));
 
         dispatch({ type: actionTypes.RETRIEVE_NOTES_SUCCESS, notes });
@@ -49,13 +48,15 @@ export const getUserNoteAction = (noteId, history) => {
     // get all notes from localstorage when offline
 
     function offlineMode () {
-      let notes = JSON.parse(localStorage.notes);
+      if (localStorage && localStorage.notes) {
+        let notes = JSON.parse(localStorage.notes);
 
-      let requestedNote = notes.find((noteObj) => {
-        return noteObj._id == noteId;
-      });
+        let requestedNote = notes.find((noteObj) => {
+          return noteObj._id == noteId;
+        });
 
-      dispatch({ type: actionTypes.RETRIEVE_SINGLE_NOTE_SUCCESS, note: requestedNote });
+        dispatch({ type: actionTypes.RETRIEVE_SINGLE_NOTE_SUCCESS, note: requestedNote });
+      }
     }
 
     if (navigator.onLine) {
@@ -136,25 +137,53 @@ export const deleteUserNoteAction = (noteId) => {
       if (localStorage && localStorage.notes) {
         let localStorageParsedNotes = JSON.parse(localStorage.getItem('notes'));
 
-        // loop to move note to be deleted from localStorage.notes
+        // remove the note from the localstorage notes because it is deleted
         let noteToBeDeleted = localStorageParsedNotes.find((note, index) => {
           if (noteId == note._id) {
             localStorageParsedNotes.splice(index, 1);
           }
           return noteId == note._id;
         });
+
+        // when creating and deleting a note offline
+        // we need to remove it from the createdNotes array
+
+        let noteCreatedAndDeletedOffline = false;
+
+        if (localStorage.createdNotes) {
+          let parsedCreatedNotes = JSON.parse(localStorage.createdNotes);
+
+          for (let i = 0; i < parsedCreatedNotes.length; i++) {
+            if (parsedCreatedNotes[i]._id == noteToBeDeleted._id) {
+              noteCreatedAndDeletedOffline = true;
+              parsedCreatedNotes.splice(i, 1);
+              break;
+            }
+          }
+
+          if (parsedCreatedNotes.length === 0) {
+            localStorage.removeItem('createdNotes');
+          } else {
+            localStorage.setItem('createdNotes', JSON.stringify(parsedCreatedNotes))
+          }
+        }
+
         localStorage.setItem('notes', JSON.stringify(localStorageParsedNotes));
         dispatch(GetAllUserNotesAction());
 
         // check to see if there is already a local deletedNotes array
-        if (localStorage.deletedNotes === undefined) {
-          localStorage.setItem('deletedNotes', JSON.stringify([noteToBeDeleted]));
+
+        if (!noteCreatedAndDeletedOffline) {
+          if (localStorage.deletedNotes === undefined) {
+            localStorage.setItem('deletedNotes', JSON.stringify([noteToBeDeleted]));
+          }
+          else {
+            let deletedNotes = JSON.parse(localStorage.deletedNotes);
+            deletedNotes.push(noteToBeDeleted);
+            localStorage.setItem('deletedNotes', JSON.stringify(deletedNotes));
+          }
         }
-        else {
-          let deletedNotes = JSON.parse(localStorage.deletedNotes);
-          deletedNotes.push(noteToBeDeleted);
-          localStorage.setItem('deletedNotes', JSON.stringify(deletedNotes));
-        }
+
       }
     };
 
@@ -180,18 +209,93 @@ export const deleteUserNoteAction = (noteId) => {
 
 export const updateUserNoteAction = (note, history) => {
   return (dispatch, getState) => {
-    fetch(config.BACKEND_URL + '/note/' + note._id, {
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      method: 'PUT',
-      body: JSON.stringify(note)
-    })
-    .then(res => {
-      history.push('/note/' + note._id);
-      dispatch({ type: actionTypes.UPDATE_NOTE_SUCCESS });
-    })
-    .catch(err => {
-      dispatch({ type: actionTypes.UPDATE_NOTE_ERROR, err });
-    });
+    note.lastSaved = new Date();
+
+    // use localstorage for offline mode
+
+    function offlineMode () {
+      if (localStorage && localStorage.notes) {
+        let parsedNotes = JSON.parse(localStorage.notes);
+
+        // remove the note that is updated in the localStrage notes
+        // array and replace it with the latest note that
+        // was made by the user
+        for (let i = 0; i < parsedNotes.length; i++) {
+          if (parsedNotes[i]._id == note._id) {
+            parsedNotes.splice(i, 1, note)
+          }
+        }
+
+        // if the note was created offline
+        // we need to update the note in the createdNotes array
+        // and not push it into the updatedNotes array
+        // because it has a fake ID
+
+        let noteCreatedOffline = false;
+        if (localStorage.createdNotes) {
+          let parsedCreatedNotesArray = JSON.parse(localStorage.createdNotes)
+          
+          for (let i = 0; i < parsedCreatedNotesArray.length; i++) {
+            if (parsedCreatedNotesArray[i]._id == note._id) {
+              noteCreatedOffline = true;
+              parsedCreatedNotesArray.splice(i, 1, note);
+              break;
+            }
+          }
+
+          localStorage.setItem('createdNotes', JSON.stringify(parsedCreatedNotesArray));
+        }
+
+        // if the note was edited more then once replace it
+        if (localStorage.updatedNotes) {
+          let parsedUpdatedNotes = JSON.parse(localStorage.updatedNotes);
+
+          for (let i = 0; i < parsedUpdatedNotes.length; i++) {
+            if (parsedUpdatedNotes[i]._id == note._id) {
+              parsedUpdatedNotes.splice(i, 1);
+              break;
+            }
+          }
+
+          localStorage.setItem('updatedNotes', JSON.stringify(parsedUpdatedNotes))
+        }               
+
+        // if the note was created offline and it was updated
+        // do not push it into the updatedNotes array
+
+        if (!noteCreatedOffline) {
+          if (localStorage.updatedNotes === undefined) {
+            localStorage.setItem('updatedNotes', JSON.stringify([note]));
+          } else {
+            let updatedNotes = JSON.parse(localStorage.updatedNotes);
+            updatedNotes.push(note);
+            localStorage.setItem('updatedNotes', JSON.stringify(updatedNotes));
+          }
+        }
+
+        localStorage.setItem('notes', JSON.stringify(parsedNotes));
+
+        history.push('/note/' + note._id);
+      }
+    }
+    
+    
+    if (navigator.onLine) {
+      fetch(config.BACKEND_URL + '/note/' + note._id, {
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        method: 'PUT',
+        body: JSON.stringify(note)
+      })
+      .then(res => {
+        history.push('/note/' + note._id);
+        dispatch({ type: actionTypes.UPDATE_NOTE_SUCCESS });
+      })
+      .catch(err => {
+        dispatch({ type: actionTypes.UPDATE_NOTE_ERROR, err });
+      });
+    } else {
+      offlineMode();
+    }
   }
 }


### PR DESCRIPTION
update as per issue #62 

*  update the backend to only update a note only if the current last saved date is more recent then the last saved stored in the db
* the model to hold lastSaved and createdAt properties

add
* send a request to update the note every 5 seconds
* when creating and deleting a note offline delete the note from the createdNotes array and dont add it into the deleteNotes array because the note never existed in the DB
* when creating a note and updating a note offline it needs to be stored in the createdNotes array and not put into the updatedNotes array because it never existed so it has a fake ID
* offline mode for updating a note
